### PR TITLE
FE-27: briefing list api 호출 / 모바일 반응형 UI 구현

### DIFF
--- a/breifing/package-lock.json
+++ b/breifing/package-lock.json
@@ -15,7 +15,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "axios": "^1.4.0",
+        "axios": "^1.5.1",
         "dayjs": "^1.11.10",
         "react": "^18.2.0",
         "react-cookie": "^6.1.1",
@@ -5820,9 +5820,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/breifing/package.json
+++ b/breifing/package.json
@@ -10,7 +10,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "axios": "^1.4.0",
+    "axios": "^1.5.1",
     "dayjs": "^1.11.10",
     "react": "^18.2.0",
     "react-cookie": "^6.1.1",

--- a/breifing/src/components/ManagingDatePicker.js
+++ b/breifing/src/components/ManagingDatePicker.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
@@ -32,9 +32,8 @@ function ManagingDatePicker() {
                     label="Responsive variant"
                     components={["DatePicker"]}
                 >
-                    <div className="bg-white rounded-md p-1 ">
+                    <div className="bg-white rounded-md">
                         <DatePicker
-                            label={`${selectedDate}`}
                             value={selectedDate.date}
                             slotProps={{
                                 textField: {

--- a/breifing/src/components/ManagingDatePicker.js
+++ b/breifing/src/components/ManagingDatePicker.js
@@ -24,17 +24,21 @@ function ManagingDatePicker() {
 
     return (
         <div>
-            <div>
-                <LocalizationProvider
-                    dateAdapter={AdapterDayjs}
-                    dateFormats={datePickerUtils}
+            <LocalizationProvider
+                dateAdapter={AdapterDayjs}
+                dateFormats={datePickerUtils}
+            >
+                <DemoContainer
+                    label="Responsive variant"
+                    components={["DatePicker"]}
                 >
-                    <DemoContainer components={["DatePicker"]}>
+                    <div className="bg-white rounded-md p-1 ">
                         <DatePicker
+                            label={`${selectedDate}`}
                             value={selectedDate.date}
                             slotProps={{
                                 textField: {
-                                    size: "medium",
+                                    size: "small",
                                 },
                             }}
                             format={datePickerFormat}
@@ -42,9 +46,9 @@ function ManagingDatePicker() {
                                 handleDateChange(newValue);
                             }}
                         />
-                    </DemoContainer>
-                </LocalizationProvider>
-            </div>
+                    </div>
+                </DemoContainer>
+            </LocalizationProvider>
         </div>
     );
 }

--- a/breifing/src/components/ManagingHeader.js
+++ b/breifing/src/components/ManagingHeader.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { ReactComponent as Exit } from "../assets/images/exit.svg";
 import ManagingDatePicker from "./ManagingDatePicker";
 import { useCookies } from "react-cookie";
@@ -12,7 +12,7 @@ function ManagingHeader({ showDatepicker }) {
         <div className="navbar bg-primaryBgColor">
             {/* 로고 */}
             <div className="navbar-start">
-                <a className="btn btn-ghost no-animation normal-case text-xl text-white">
+                <a className="btn btn-ghost no-animation normal-case lg:text-xl sm:text-base text-white">
                     Briefing
                 </a>
             </div>
@@ -26,10 +26,10 @@ function ManagingHeader({ showDatepicker }) {
                     onClick={() => {
                         handleLogout();
                     }}
-                    className="btn btn-ghost text-white border-none"
+                    className="btn btn-ghost lg:text-xl sm:text-base text-white border-none"
                 >
-                    나가기
-                    <Exit className="w-9 h-9 pt-1 fill-white" />
+                    <div className="lg:inline sm:hidden pb-1">나가기</div>
+                    <Exit className="lg:w-11 lg:h-11 sm:w-10 sm:h-10 pt-1 fill-white" />
                 </button>
             </div>
         </div>

--- a/breifing/src/components/ManagingHeader.js
+++ b/breifing/src/components/ManagingHeader.js
@@ -12,12 +12,12 @@ function ManagingHeader({ showDatepicker }) {
         <div className="navbar bg-primaryBgColor">
             {/* 로고 */}
             <div className="navbar-start">
-                <a className="btn btn-ghost no-animation normal-case lg:text-xl sm:text-base text-white">
+                <a className="btn btn-ghost no-animation normal-case lg:font-bold sm:font-bold lg:text-xl sm:text-base text-white">
                     Briefing
                 </a>
             </div>
             {/* 날짜 선택창 */}
-            <div className="navbar-center">
+            <div className="navbar-center pb-2">
                 {showDatepicker && <ManagingDatePicker />}
             </div>
             {/* 나가기 버튼 */}

--- a/breifing/src/pages/BriefList.js
+++ b/breifing/src/pages/BriefList.js
@@ -10,6 +10,7 @@ function BriefList() {
     const [password, setPassword] = useState("");
     const [cookies, setCookie, removeCookie] = useCookies(["loggedIn"]);
     const [selectedDate, setSelectedDate] = useRecoilState(managingDateState);
+    const [inputError, setInputError] = useState(false);
 
     useEffect(() => {
         console.log("selectedDate:", selectedDate);
@@ -25,6 +26,8 @@ function BriefList() {
                 alert("세션이 만료되었습니다. 다시 로그인해주세요.");
                 window.location.reload();
             }, time * 1000); // 3초 후에 실행
+        } else {
+            setInputError(true);
         }
     };
 
@@ -36,7 +39,7 @@ function BriefList() {
                     <ManagingHeader showDatepicker={true} />
                     <div className="h-screen bg-primaryBgColor flex flex-col items-center pt-5">
                         {/* YYYY.MM.DD 키워드 브리핑 */}
-                        <div className="title text-5xl text-white font-bold">
+                        <div className="title text-5xl md:text-4xl sm:text-2xl text-white font-bold">
                             {selectedDate} 키워드 브리핑
                         </div>
                         <div className="lastUpdate text-gray-300 text-sm mt-3">
@@ -92,11 +95,18 @@ function BriefList() {
                     </div>
 
                     <input
-                        className="input w-full max-w-xs mt-8"
+                        className={`input w-48 ${
+                            inputError ? "input-bordered input-error" : ""
+                        } max-w-xs mt-8`}
                         type="password"
                         placeholder="Enter the Code"
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                handleLogin(password);
+                            }
+                        }}
                     />
                     <button
                         className="btn w-32 bg-white text-primaryBgColor mt-3"

--- a/breifing/src/pages/BriefList.js
+++ b/breifing/src/pages/BriefList.js
@@ -76,7 +76,7 @@ function BriefList() {
                         </div>
 
                         {/* brief list */}
-                        <div className="flex flex-col my-3">
+                        <div className="flex flex-col lg:w-2/3 sm:w-5/6 my-3">
                             {/* brief card */}
                             {isLoading ? (
                                 <div className="text-white">Loading...</div>
@@ -91,7 +91,7 @@ function BriefList() {
                                     <Link to={`briefing/${briefing.id}`}>
                                         <div
                                             key={index}
-                                            className="flex flex-row lg:h-20 sm:h-16 border-none bg-white mt-3 card rounded-box place-items-center"
+                                            className="flex flex-row w-full lg:h-20 sm:h-16 border-none bg-white mt-3 card rounded-box place-items-center"
                                         >
                                             <div className="briefing-rank lg:text-lg sm:text-base lg:px-8 sm:px-5 text-primaryTextColor">
                                                 {briefing.ranks}

--- a/breifing/tailwind.config.js
+++ b/breifing/tailwind.config.js
@@ -50,12 +50,12 @@ module.exports = {
                 primaryTextColor: "#134D80",
                 secondBgColor: "#F7F7F7",
                 secondTextColor: "#B6B6B6",
+                thirdTextColor: "#93A8D0",
             },
         },
         screens: {
-            sm: { min: "390px", max: "819px" },
-            md: { min: "820px", max: "1023px" },
-            lg: { min: "1024px" },
+            sm: "375px", // mobile screen size
+            lg: "768px", // tablet, desktop screen size
         },
     },
     plugins: [require("daisyui")],


### PR DESCRIPTION
- screen 단위를 sm: 모바일(375 ~ 768px), lg: 타블렛 및 데스크탑(768px ~) 총 2가지 버전으로 수정
- 모바일 스크린 : 차지하는 가로 비율 w-2/3 로 설정
- 타블렛 및 데스크탑 스크린 : 차지하는 가로 비율 w-5/6 으로 설정
- text 크기
> lg: text-4xl, sm: text-2xl
lg: text-lg, sm: text-base
lg: text-base, sm: text-sm

lg 버전
<img width="1459" alt="image" src="https://github.com/Team-Shaka/Breifing-WEB/assets/71630722/1c96245a-a592-45b5-ad4e-bdbb74fc67f8">
sm 버전
![image](https://github.com/Team-Shaka/Breifing-WEB/assets/71630722/05e8630e-52b7-4f49-8fb9-1341a3d85749)
